### PR TITLE
Fix WAIC penalty term accumulation bug

### DIFF
--- a/src/fit_utils.jl
+++ b/src/fit_utils.jl
@@ -83,7 +83,7 @@ function calc_waic(dists::Vector{T}, dd::DegreeDist
 		lppd += lppd1 * dd.y[i]
 
 		p_waic1 = ll |> var
-		p_waic = p_waic1 * dd.y[i]
+		p_waic += p_waic1 * dd.y[i]
 	end
 	return -2 * (lppd - p_waic)
 end


### PR DESCRIPTION
## Summary
- Fixed critical bug in `calc_waic` function where the penalty term `p_waic` was being overwritten instead of accumulated in each loop iteration
- Changed `p_waic = p_waic1 * dd.y[i]` to `p_waic += p_waic1 * dd.y[i]`

## Impact
This bug caused incorrect WAIC values to be calculated, which could lead to wrong model selection. The fix ensures proper accumulation of the penalty term across all data points.

## Test plan
- [ ] Re-run `2j_fit_surveys.ipynb` to regenerate WAIC values
- [ ] Verify model selection results

Fixes #1