### PR TITLE
Fix variable reference bug in remove_cnt_home_na

### DIFF
--- a/src/data_setup.jl
+++ b/src/data_setup.jl
@@ -42,7 +42,7 @@ function remove_cnt_home_na(df::DataFrame, df_part::DataFrame)
 	ids_rem = df[.~cond, :part_id_d] |> unique
 	println("Number of removing ids: ", length(ids_rem))
 	ids_part = df_part[:, :part_id_d]
-	ids_incl = [id for id in ids_part if (ids_part in ids_rem) == false]
+	ids_incl = [id for id in ids_part if (id in ids_rem) == false]
 	df_part_clean = @subset(df_part, in.(:part_id_d, Ref(ids_incl)))
 	return df_clean, df_part_clean
 end


### PR DESCRIPTION
## Summary
- Fixed bug where the function checked if entire vector `ids_part` was in `ids_rem`, instead of checking individual IDs
- Changed `ids_part in ids_rem` to `id in ids_rem`

## Impact
This bug caused incorrect data filtering for all surveys.

## Test plan
- [ ] Run `1j_data_setup.ipynb` to verify data loading works correctly

Fixes #2