### PR TITLE
Fix undefined variable in plot_ccdf function

### DIFF
--- a/src/degree_dist.jl
+++ b/src/degree_dist.jl
@@ -82,11 +82,11 @@ end
 plot_ccdf!(pl::Plots.Plot, x::Vector{Int64}; kwds...) = plot_ccdf!(pl, DegreeDist(x); kwds...)
 
 function plot_ccdf(dd::DegreeDist; kwds...)::Plots.Plot
-	y_ccdf = obtain_ccdf(dh)
+	y_ccdf = obtain_ccdf(dd)
 	pl = plot(; xaxis = :log10, xlabel = "log10(k)", ylabel = "log10(ccdf(k))",
 		xlim = [1, 10000],
 	)
-	scatter!(pl, dh.x, log10.(y_ccdf); kwds...)
+	scatter!(pl, dd.x, log10.(y_ccdf); kwds...)
 	return pl
 end
 plot_ccdf(x::Vector{Int64}; kwds...)::Plots.Plot = plot_ccdf(DegreeDist(x); kwds...)


### PR DESCRIPTION
## Summary
- Fixed typo where `dh` was used instead of parameter `dd` in `plot_ccdf` function
- Changed both occurrences on lines 85 and 89

## Impact
This function would throw an `UndefVarError` when called.

Fixes #4