### PR TITLE
Fix undefined variables in fit_convoluted_dist

### DIFF
--- a/src/comix2_utils.jl
+++ b/src/comix2_utils.jl
@@ -195,6 +195,10 @@ end
 function fit_convoluted_dist(df_dds::DataFrame)
     dd_all, dd_hm, dd_nhm = get_comix2_dd_all_hm_nhm()
 
+    # Load fitted chains for priors
+    res = load("../dt_intermediate/CoMix2_chns.jld2")["result"]
+    model_names = get_model_names()
+
     chn_hm = res["chns_home"][model_names[2]]
     chn_nhm = res["chns_non-home"][model_names[3]]
     df_chn_hm = DataFrame(chn_hm);


### PR DESCRIPTION
## Summary
- Added loading of `res` from `CoMix2_chns.jld2` file
- Added call to `get_model_names()` to define `model_names`
- These variables were used but never defined, causing the function to fail

## Impact
This function would throw an `UndefVarError` when called.

Fixes #5