### PR TITLE
Fix wrong variable name in error message

### DIFF
--- a/src/turing_utils.jl
+++ b/src/turing_utils.jl
@@ -69,7 +69,7 @@ function get_ZeroInfDist(chn::Chains, key::String)
 	elseif key == "ZeroInfPoissonLomax"
 		return get_ZeroInfPoissonLomax(chn)
 	else
-		error("not applicable: ", model_name)
+		error("not applicable: ", key)
 	end
 end
 


### PR DESCRIPTION
## Summary
- Changed `model_name` to `key` in error message in `get_ZeroInfDist` function
- The variable `model_name` was undefined; `key` is the correct parameter name

## Impact
Low - only affects error message clarity when an invalid key is passed.

Fixes #7