### PR TITLE
Fix PoissonLomax CDF formula for discrete distribution

### DIFF
--- a/src/distributions/poisson_mixture.jl
+++ b/src/distributions/poisson_mixture.jl
@@ -141,5 +141,5 @@ function Distributions.logpdf(d::PoissonLomax, k::Int64)
 	int, err = quadgk(u -> integrand(u * k_tmp) * k_tmp, 1e-6, Inf, rtol = 1e-8)
 	return log(int)
 end
-Distributions.cdf(d::PoissonLomax, k::Int64)::Real = 1 - (1+k/d.θ)^(-d.α)
+Distributions.cdf(d::PoissonLomax, k::Int64)::Real = sum(pdf(d, i) for i in 0:k)
 


### PR DESCRIPTION
## Summary
Fixes the incorrect CDF implementation for `PoissonLomax` distribution.

## Changes
- Changed `PoissonLomax` CDF from using the continuous Lomax formula `1 - (1+k/θ)^(-α)` to the correct discrete formula `sum(pdf(d, i) for i in 0:k)`

## Issue
Closes #20

## Details
The previous implementation incorrectly used the CDF formula for the Lomax distribution (a continuous distribution). Since `PoissonLomax` is a discrete distribution, the CDF must be computed by summing the probability density function values from 0 to k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)